### PR TITLE
Add Reference Link Plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16343,5 +16343,12 @@
     "author": "Ankit Kapur",
     "description": "Automatically updates a 'status' property in a note when its card is moved on a Kanban board",
     "repo": "ankit-kapur/obsidian-kanban-status-updater-plugin"
+},
+{
+    "id": "obsidian-reference-link-plugin",
+    "name": "Reference Link Plugin",
+    "author": "njko39",
+    "description": "Enables reference-style Markdown links in reading mode and hides link definitions, like in Kramdown",
+    "repo": "njko39/obsidian-reference-link-plugin"
 }
 ]


### PR DESCRIPTION
Adds a plugin that enables reference-style Markdown links like in Kramdown.
- `[Label]` becomes a clickable link in Reading Mode
- Reference definitions like `[Label]: https://...` are hidden from view
- Useful for clean Markdown documents

Example:

```markdown

A simple plugin for [Obsidian]. It does have [GitHub page]! 

[//]: # (Comments & links:)

[GitHub page]: https://github.com/njko39/obsidian-reference-link-plugin
[Obsidian]: https://obsidian.md/
```

Will be displayed in reading mode as:

A simple plugin for [Obsidian](https://obsidian.md/). It does have [GitHub page](https://github.com/njko39/obsidian-reference-link-plugin)! 
